### PR TITLE
chores: switch to python-lsp-server and fix typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,6 @@ apk add --no-cache libsodium
 apt-get install -y libsodium23
 ```
 
-# Dev
-
-Enable dev-env:
-
-```bash
-pyenv install 3.10.2
-poetry env use $HOME/.pyenv/versions/3.10.2/bin/python3.10
-poetry install
-poetry shell
-docker-compose up -d db
-(cd manabi_django && ./manage.py migrate manabi_migrations)
-```
-
 ## Config
 
 Call `manabi-keygen` and add the key to `config["manabi"]["key"]`. The key is
@@ -83,3 +70,25 @@ config = {
 }
 dav_app = ManabiDAVApp(config)
 ```
+
+# Dev
+
+Enable dev-env:
+
+```bash
+pyenv install 3.10.2
+poetry env use $HOME/.pyenv/versions/3.10.2/bin/python3.10
+poetry install
+poetry shell
+docker-compose up -d db
+(cd manabi_django && ./manage.py migrate manabi_migrations)
+```
+
+## Typing rules
+
+My typing rules for this project (there are no company rules):
+
+- In tests `# type: ignore` is allowed if fixing the issue does not help production-code
+- In production-code `# type: ignore` is allowed if a manual check happens or
+  we can guarantee some runtime behavior. For example we guarantee that a
+  weakref is always valid. Similar to `unsafe` in rust.

--- a/manabi/filesystem.py
+++ b/manabi/filesystem.py
@@ -14,7 +14,11 @@ from .token import Token
 class ManabiFolderResource(FolderResource):
     def get_member_names(self):
         token: Token = self.environ["manabi.token"]
-        path = Path(self._file_path, token.path)
+        # type manually checked
+        token_path: Path = token.path  # type: ignore
+        if not token_path:
+            return []
+        path = Path(self._file_path, token_path)
         if path.exists():
             return [str(token.path)]
         else:

--- a/manabi/lock.py
+++ b/manabi/lock.py
@@ -62,7 +62,6 @@ class ManabiShelfLock(ManabiContextLockMixin):
     _storage_object: Callable[[], "ManabiShelfLockLockStorage"]
 
     def __init__(self, storage_path, storage_object: "ManabiShelfLockLockStorage"):
-        print("foundme", type(storage_object))
         self._storage_path = storage_path
         # type manually checked
         self._storage_object = weakref.ref(storage_object)  # type: ignore

--- a/manabi/lock.py
+++ b/manabi/lock.py
@@ -11,7 +11,7 @@ from typing import Callable
 
 import psycopg2.extensions
 from psycopg2 import InterfaceError, OperationalError, connect
-from psycopg2.extensions import connection as PsycopConnection
+from psycopg2.extensions import connection as PsycopgConnection
 from wsgidav.lock_man.lock_storage import LockStorageDict  # type: ignore
 from wsgidav.util import get_module_logger  # type: ignore
 
@@ -19,14 +19,14 @@ _logger = get_module_logger(__name__)
 
 
 class ManabiTimeoutMixin:
-    _max_timeout: int = 0
+    _max_timeout: float = 0
 
     @property
     def max_timeout(self) -> float:
         return self._max_timeout
 
     @max_timeout.setter
-    def max_timeout(self, value: int) -> None:
+    def max_timeout(self, value: float) -> None:
         if value <= 0:
             raise ValueError("max_timeout must be a positive integer.")
         self._max_timeout = value
@@ -265,7 +265,7 @@ class ManabiPostgresDict(MutableMapping):
 
 
 class ManabiDbLockStorage(LockStorageDict, ManabiTimeoutMixin):
-    _connection: PsycopConnection
+    _connection: PsycopgConnection
 
     def __init__(self, refresh: float, postgres_dsn: str):
         super().__init__()

--- a/manabi/lock.py
+++ b/manabi/lock.py
@@ -4,16 +4,16 @@ import shelve
 import threading
 import traceback
 import weakref
+from abc import ABC, abstractmethod
 from collections.abc import MutableMapping
 from pathlib import Path
-from abc import ABC, abstractmethod
+from typing import Callable
 
 import psycopg2.extensions
-from psycopg2.extensions import connection as PsycopConnection
 from psycopg2 import InterfaceError, OperationalError, connect
+from psycopg2.extensions import connection as PsycopConnection
 from wsgidav.lock_man.lock_storage import LockStorageDict  # type: ignore
 from wsgidav.util import get_module_logger  # type: ignore
-from typing import Callable
 
 _logger = get_module_logger(__name__)
 

--- a/manabi/token_test.py
+++ b/manabi/token_test.py
@@ -19,16 +19,19 @@ def test_key_validator(config):
     key = Key.from_dictionary(config)
     assert len(key.data) == 32
     with pytest.raises(TypeError):
-        key.data = "huhu"
+        # well we want to test what happens if it is not correctly typed
+        key.data = "huhu"  # type: ignore
     with pytest.raises(ValueError):
-        key.data = b"huhu"
+        # well we want to test what happens if it is not correctly typed
+        key.data = b"huhu"  # type: ignore
 
 
 def test_ttl_validator(config):
     ttl = TTL.from_dictionary(config)
     assert ttl.initial == 600
     with pytest.raises(TypeError):
-        ttl.initial = "huhu"
+        # well we want to test what happens if it is not correctly typed
+        ttl.initial = "huhu"  # type: ignore
     assert ttl.initial == 600
 
 
@@ -38,7 +41,8 @@ def test_config_validator(config):
     assert cfg.ttl.initial == 600
     assert cfg.ttl.refresh == 600
     with pytest.raises(TypeError):
-        cfg.key = "huhu"
+        # well we want to test what happens if it is not correctly typed
+        cfg.key = "huhu"  # type: ignore
 
 
 def test_token_invalid_past(config):
@@ -76,8 +80,8 @@ def test_token_creation(config):
     assert token2.check() == State.valid
     assert token2.check(10) == State.valid
     assert token2.check(-10) == State.expired
-    assert token2.timestamp < now() + 10
-    assert token2.timestamp > now() - 10
+    assert token2.timestamp < now() + 10  # type: ignore
+    assert token2.timestamp > now() - 10  # type: ignore
     assert token2.initial(cfg.ttl) == State.valid
     assert token2.refresh(cfg.ttl) == State.valid
 
@@ -89,8 +93,8 @@ def test_token_creation(config):
     assert token.check() == State.valid
     assert token.check(10) == State.valid
     assert token.check(-10) == State.expired
-    assert token.timestamp < now() + 10
-    assert token.timestamp > now() - 10
+    assert token.timestamp < now() + 10  # type: ignore
+    assert token.timestamp > now() - 10  # type: ignore
 
     token = Token(cfg.key)
     assert token.check() == State.invalid

--- a/manabi/util_test.py
+++ b/manabi/util_test.py
@@ -18,5 +18,6 @@ class CallableClass:
 
 def test_callable():
     with pytest.raises(ValueError):
-        CallableClass(True)
+        # well we want to test what happens if it is not correctly typed
+        CallableClass(True)  # type: ignore
     CallableClass(test_callable)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1390,6 +1390,24 @@ tomli = {version = "*", markers = "python_version < \"3.11\""}
 dev = ["flake8", "isort (>=5.0)", "mypy", "pre-commit", "pytest", "types-pkg-resources", "types-setuptools"]
 
 [[package]]
+name = "python-lsp-isort"
+version = "0.1"
+description = "isort plugin for the Python LSP Server"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-lsp-isort-0.1.tar.gz", hash = "sha256:f02948bc8e7549905032100e772f03464f7548afa96f07d744ff1f93cc58339a"},
+]
+
+[package.dependencies]
+isort = ">=5.0"
+python-lsp-server = "*"
+
+[package.extras]
+dev = ["pytest"]
+
+[[package]]
 name = "python-lsp-jsonrpc"
 version = "1.0.0"
 description = "JSON RPC 2.0 server library"
@@ -2017,4 +2035,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "a42324fbf37e69b4990568b87ba6b5a866dd71957cf8c8bb9d2c32c29a246644"
+content-hash = "849ccdad56de3d7841f1e72faa5f7ae43e428c58275bda61be376701d9f8588b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,6 +417,18 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "docstring-to-markdown"
+version = "0.12"
+description = "On the fly conversion of Python docstrings to markdown"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "docstring-to-markdown-0.12.tar.gz", hash = "sha256:40004224b412bd6f64c0f3b85bb357a41341afd66c4b4896709efa56827fb2bb"},
+    {file = "docstring_to_markdown-0.12-py3-none-any.whl", hash = "sha256:7df6311a887dccf9e770f51242ec002b19f0591994c4783be49d24cdc1df3737"},
+]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -1358,53 +1370,76 @@ autocompletion = ["argcomplete (>=1.10.0,<3)"]
 yaml = ["PyYaml (>=5.2)"]
 
 [[package]]
-name = "python-jsonrpc-server"
-version = "0.4.0"
+name = "python-lsp-black"
+version = "1.3.0"
+description = "Black plugin for the Python LSP Server"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-lsp-black-1.3.0.tar.gz", hash = "sha256:5aa257e9e7b7e5a2316ef2a9fbcd242e82e0f695bf1622e31c0bf5cd69e6113f"},
+    {file = "python_lsp_black-1.3.0-py3-none-any.whl", hash = "sha256:5f583b4395d8d048885974095088ab81e36e501de369cc49a621a82473bb9070"},
+]
+
+[package.dependencies]
+black = ">=22.3.0"
+python-lsp-server = ">=1.4.0"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["flake8", "isort (>=5.0)", "mypy", "pre-commit", "pytest", "types-pkg-resources", "types-setuptools"]
+
+[[package]]
+name = "python-lsp-jsonrpc"
+version = "1.0.0"
 description = "JSON RPC 2.0 server library"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "python-jsonrpc-server-0.4.0.tar.gz", hash = "sha256:62c543e541f101ec5b57dc654efc212d2c2e3ea47ff6f54b2e7dcb36ecf20595"},
-    {file = "python_jsonrpc_server-0.4.0-py3-none-any.whl", hash = "sha256:e5a908ff182e620aac07db5f57887eeb0afe33993008f57dc1b85b594cea250c"},
+    {file = "python-lsp-jsonrpc-1.0.0.tar.gz", hash = "sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd"},
+    {file = "python_lsp_jsonrpc-1.0.0-py3-none-any.whl", hash = "sha256:079b143be64b0a378bdb21dff5e28a8c1393fe7e8a654ef068322d754e545fc7"},
 ]
 
 [package.dependencies]
 ujson = ">=3.0.0"
 
 [package.extras]
-test = ["coverage", "mock", "pycodestyle", "pyflakes", "pylint", "pytest", "pytest-cov", "versioneer"]
+test = ["coverage", "pycodestyle", "pyflakes", "pylint", "pytest", "pytest-cov"]
 
 [[package]]
-name = "python-language-server"
-version = "0.36.2"
+name = "python-lsp-server"
+version = "1.7.3"
 description = "Python Language Server for the Language Server Protocol"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "python-language-server-0.36.2.tar.gz", hash = "sha256:9984c84a67ee2c5102c8e703215f407fcfa5e62b0ae86c9572d0ada8c4b417b0"},
-    {file = "python_language_server-0.36.2-py2.py3-none-any.whl", hash = "sha256:a0ad0aca03f4a20c1c40f4f230c6773eac82c9b7cdb026cb09ba10237f4815d5"},
+    {file = "python-lsp-server-1.7.3.tar.gz", hash = "sha256:a31b0525be6ec831c7d2b476b744e5aa5074633e1d1b77ee97f332cde15983ea"},
+    {file = "python_lsp_server-1.7.3-py3-none-any.whl", hash = "sha256:f4ae64834da1d4312067a8ee05a76c7652167c3c90d1cef44022366d695c4c0e"},
 ]
 
 [package.dependencies]
-jedi = ">=0.17.2,<0.18.0"
-pluggy = "*"
-python-jsonrpc-server = ">=0.4.0"
-ujson = {version = ">=3.0.0", markers = "python_version > \"3\""}
+docstring-to-markdown = "*"
+jedi = ">=0.17.2,<0.19.0"
+pluggy = ">=1.0.0"
+python-lsp-jsonrpc = ">=1.0.0"
+setuptools = ">=39.0.0"
+ujson = ">=3.0.0"
 
 [package.extras]
-all = ["autopep8", "flake8 (>=3.8.0)", "mccabe (>=0.6.0,<0.7.0)", "pycodestyle (>=2.6.0,<2.7.0)", "pydocstyle (>=2.0.0)", "pyflakes (>=2.2.0,<2.3.0)", "pylint (>=2.5.0)", "rope (>=0.10.5)", "yapf"]
-autopep8 = ["autopep8"]
-flake8 = ["flake8 (>=3.8.0)"]
-mccabe = ["mccabe (>=0.6.0,<0.7.0)"]
-pycodestyle = ["pycodestyle (>=2.6.0,<2.7.0)"]
-pydocstyle = ["pydocstyle (>=2.0.0)"]
-pyflakes = ["pyflakes (>=2.2.0,<2.3.0)"]
-pylint = ["pylint (>=2.5.0)"]
-rope = ["rope (>0.10.5)"]
-test = ["coverage", "flaky", "matplotlib", "mock", "numpy", "pandas", "pylint (>=2.5.0)", "pyqt5", "pytest", "pytest-cov", "versioneer"]
-yapf = ["yapf"]
+all = ["autopep8 (>=1.6.0,<2.1.0)", "flake8 (>=5.0.0,<7)", "mccabe (>=0.7.0,<0.8.0)", "pycodestyle (>=2.9.0,<2.11.0)", "pydocstyle (>=6.3.0,<6.4.0)", "pyflakes (>=2.5.0,<3.1.0)", "pylint (>=2.5.0,<3)", "rope (>1.2.0)", "whatthepatch (>=1.0.2,<2.0.0)", "yapf (>=0.33.0)"]
+autopep8 = ["autopep8 (>=1.6.0,<2.1.0)"]
+flake8 = ["flake8 (>=5.0.0,<7)"]
+mccabe = ["mccabe (>=0.7.0,<0.8.0)"]
+pycodestyle = ["pycodestyle (>=2.9.0,<2.11.0)"]
+pydocstyle = ["pydocstyle (>=6.3.0,<6.4.0)"]
+pyflakes = ["pyflakes (>=2.5.0,<3.1.0)"]
+pylint = ["pylint (>=2.5.0,<3)"]
+rope = ["rope (>1.2.0)"]
+test = ["coverage", "flaky", "matplotlib", "numpy", "pandas", "pylint (>=2.5.0,<3)", "pyqt5", "pytest", "pytest-cov"]
+websockets = ["websockets (>=10.3)"]
+yapf = ["whatthepatch (>=1.0.2,<2.0.0)", "yapf (>=0.33.0)"]
 
 [[package]]
 name = "python-semantic-release"
@@ -1611,6 +1646,23 @@ files = [
     {file = "semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4"},
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
+
+[[package]]
+name = "setuptools"
+version = "67.8.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1965,4 +2017,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "af3d1d613959b227e7c25758e2dc7feb14e9536a3311d90c6b2cc2478c949dc3"
+content-hash = "a42324fbf37e69b4990568b87ba6b5a866dd71957cf8c8bb9d2c32c29a246644"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,12 @@ hypothesis = "^6.54.6"
 mypy = "^1.3.0"
 pdbpp = "^0.10.3"
 pytest = "^7.3.1"
-python-language-server = "^0.36.2"
 python-semantic-release = "^7.32.0"
 requests = "^2.28.1"
 types-psycopg2 = "^2.9.21"
 types-requests = "^2.28.11"
+python-lsp-server = "^1.7.3"
+python-lsp-black = "^1.3.0"
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ build_command = "poetry build"
 commit_subject = "chore(release): v{version}"
 commit_author = "github-actions <github-actions@github.com>"
 
+[tool.mypy]
+check_untyped_defs = true
+
 # No flake8 pyproject support yet, please edit .flake8
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ types-psycopg2 = "^2.9.21"
 types-requests = "^2.28.11"
 python-lsp-server = "^1.7.3"
 python-lsp-black = "^1.3.0"
+python-lsp-isort = "^0.1"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
My typing rules for this project (there are no company rules):

- In tests `# type: ignore` is allowed if fixing the issue does not help production-code
- In production-code `# type: ignore` is allowed if a manual check happens or
  we can guarantee some runtime behavior. For example we guarantee that a
  weakref is always valid. Similar to `unsafe` in rust.
