### PR TITLE
feat: add pre_write_callback and hook/callback approve write

### DIFF
--- a/manabi/conftest.py
+++ b/manabi/conftest.py
@@ -75,6 +75,15 @@ def pre_write_hook():
 
 
 @pytest.fixture()
+def pre_write_callback():
+    try:
+        mock._pre_write_callback = mock.check_token
+        yield mock.check_token
+    finally:
+        mock._pre_write_callback = None
+
+
+@pytest.fixture()
 def server_dir() -> Path:
     return mock.get_server_dir()
 

--- a/manabi/filesystem_test.py
+++ b/manabi/filesystem_test.py
@@ -6,29 +6,56 @@ import requests
 from . import mock
 
 
-def test_get_and_put(config: Dict[str, Any], server):
+@pytest.mark.parametrize("tamper, expect_status", [(True, 403), (False, 204)])
+def test_get_and_put(tamper, expect_status, config: Dict[str, Any], server):
     req = mock.make_req(config)
     res = requests.get(req)
     assert res.status_code == 200
+    if tamper:
+        i = 58
+        if req[i] == "f":
+            req = req[0:i] + "g" + req[i + 1 :]
+        else:
+            req = req[0:i] + "f" + req[i + 1 :]
     res = requests.put(req, data=res.content)
-    assert res.status_code == 204
+    assert res.status_code == expect_status
 
 
-@pytest.mark.parametrize("tamper, expect_status", [(True, 403), (False, 204)])
+@pytest.mark.parametrize(
+    "hook_status, expect_status",
+    [
+        (None, 204),
+        (403, 403),
+        (200, 204),
+    ],
+)
 def test_get_and_put_hooked(
-    tamper, expect_status, pre_write_hook, config: Dict[str, Any], server
+    hook_status, expect_status, pre_write_hook, config: Dict[str, Any], server
 ):
     assert config["pre_write_hook"] == "http://127.0.0.1/pre_write_hook"
-    with mock.with_pre_write_hook(config):
+    with mock.with_pre_write_hook(config, hook_status):
         req = mock.make_req(config)
         res = requests.get(req)
         assert res.status_code == 200
-
-        if tamper:
-            i = 58
-            if req[i] == "f":
-                req = req[0:i] + "g" + req[i + 1 :]
-            else:
-                req = req[0:i] + "f" + req[i + 1 :]
         res = requests.put(req, data=res.content)
         assert res.status_code == expect_status
+
+
+@pytest.mark.parametrize("callback_return, expect_status", [(False, 403), (True, 204)])
+def test_get_and_put_called(
+    callback_return,
+    expect_status,
+    pre_write_callback,
+    config: Dict[str, Any],
+    server,
+):
+    assert config["pre_write_callback"] == pre_write_callback
+    req = mock.make_req(config)
+    res = requests.get(req)
+    assert res.status_code == 200
+    try:
+        mock._check_token_return = callback_return
+        res = requests.put(req, data=res.content)
+        assert res.status_code == expect_status
+    finally:
+        mock._check_token_return = True

--- a/manabi/type_alias.py
+++ b/manabi/type_alias.py
@@ -1,4 +1,7 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from .token import Token
 
 try:
     from typing import TypeAlias
@@ -18,3 +21,4 @@ PropType = Union[
     bool,
 ]
 OptionalProp = Optional[PropType]
+PreWriteType = Callable[["Token"], bool]


### PR DESCRIPTION
If the API were unavailable and the version was not created, we prefer not to proceed with writing, as it would result in the loss of that particular version.