### PR TITLE
chore(mc): use `alias set` instead of `config host` as its removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       MINIO_ROOT_PASSWORD: secretsecret
     entrypoint: >
       /bin/sh -c "
-      mc config host add dc-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD} --api S3v4;
+      mc alias set dc-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD} --api S3v4;
       mc mb dc-minio/manabi-media;
       true"
     depends_on:


### PR DESCRIPTION
`config host` has been deprecated for quite some time and is removed now.